### PR TITLE
Refactor ProductCard component and simplify UI

### DIFF
--- a/app/components/ProductCard.tsx
+++ b/app/components/ProductCard.tsx
@@ -1,407 +1,299 @@
-"use client";
+import React, { useMemo, useState } from "react";
+import type { Product, ProductGroup, SelectedOptions, CountryMap } from "@/app/types/product";
 
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Camera } from "lucide-react";
-import ProductImage from "@/app/components/ProductImage";
-import { WhatsAppIcon } from "./WhatsAppIcon";
-import { CATEGORY_ID_NAME_MAP } from "@/app/(admin)/const/category";
-import { IMAGE_PLACEHOLDER, resolveImageSrc } from "@/app/lib/image";
-import type { Product, ProductGroup } from "@/app/types/product";
-
-interface GalleryImage {
-  image_url: string;
-  public_id: string;
-  is_cover: boolean;
-  sort_order: number;
-}
-
-interface ProductCardProps {
+interface Props {
   group: ProductGroup;
   isEnglish: boolean;
-  isSessionValid: boolean;
-  userRole: string;
-  selectedOptions: {
-    [groupKey: string]: { variation?: string; countryId?: string; weight?: string };
-  };
+  selectedOptions: SelectedOptions;
   currentQuantityByProductId: Record<number, number>;
-  countryMap: { [key: string]: { name: string; chineseName: string } };
+  countryMap: CountryMap;
+  isSessionValid: boolean;
   isLoggingIn: boolean;
-  reorderedProductIds?: number[];
+  userRole: string;
+  reorderedProductIds: number[];
   onOptionChange: (
     groupKey: string,
     type: "variation" | "countryId" | "weight",
     value: string
   ) => void;
   onAddToOrder: (product: Product) => void;
-  onUpdateQuantity: (productId: number, newQuantity: number) => void;
+  onUpdateQuantity: (productId: number, qty: number) => void;
   onCustomerService: () => void;
   onOpenPhotoEditor: (product: Product) => void;
   onOpenSignupModal: () => void;
 }
 
-const getCategoryName = (category: string | number) =>
-  CATEGORY_ID_NAME_MAP[String(category)] || "Unknown Category";
+export const ProductCard = ({
+  group,
+  isEnglish,
+  selectedOptions,
+  currentQuantityByProductId,
+  countryMap,
+  isSessionValid,
+  isLoggingIn,
+  userRole,
+  reorderedProductIds,
+  onOptionChange,
+  onAddToOrder,
+  onUpdateQuantity,
+  onCustomerService,
+  onOpenPhotoEditor,
+  onOpenSignupModal,
+}: Props) => {
+  const [activeImageIndex, setActiveImageIndex] = useState(0);
 
-const ProductCardContent = memo<ProductCardProps>(
-  ({
-    group,
-    isEnglish,
-    isSessionValid,
-    userRole,
-    selectedOptions,
-    currentQuantityByProductId,
-    countryMap,
-    isLoggingIn,
-    reorderedProductIds = [],
-    onOptionChange,
-    onAddToOrder,
-    onUpdateQuantity,
-    onCustomerService,
-    onOpenPhotoEditor,
-    onOpenSignupModal,
-  }) => {
-    const { groupKey, products } = group;
+  const allVariations = useMemo(() => {
+    return Array.from(
+      new Set(group.products.map((p) => p.Variation).filter(Boolean))
+    ) as string[];
+  }, [group.products]);
 
-    const uniq = (arr: Array<string | undefined | null>) =>
-      Array.from(new Set(arr.filter(Boolean).map((v) => String(v).trim()))).filter(Boolean);
+  const allCountries = useMemo(() => {
+    return Array.from(
+      new Set(group.products.map((p) => p.Country).filter(Boolean))
+    ) as string[];
+  }, [group.products]);
 
-    const getMatchingProduct = useCallback(
-      (
-        selection: { variation?: string; countryId?: string; weight?: string },
-        changedType?: "variation" | "countryId" | "weight"
-      ) => {
-        const exact = products.find(
-          (p) =>
-            (!selection.variation || p.Variation === selection.variation) &&
-            (!selection.countryId || p.Country === selection.countryId) &&
-            (!selection.weight || p.weight === selection.weight)
-        );
-        if (exact) return exact;
+  const allWeights = useMemo(() => {
+    return Array.from(
+      new Set(group.products.map((p) => p.weight).filter(Boolean))
+    ) as string[];
+  }, [group.products]);
 
-        if (changedType === "variation") {
-          return products.find((p) => p.Variation === selection.variation) || products[0];
-        }
-        if (changedType === "countryId") {
-          return products.find((p) => p.Country === selection.countryId) || products[0];
-        }
-        if (changedType === "weight") {
-          return products.find((p) => p.weight === selection.weight) || products[0];
-        }
+  const selectedVariation = selectedOptions[group.groupKey]?.variation ?? "";
+  const selectedCountry = selectedOptions[group.groupKey]?.countryId ?? "";
+  const selectedWeight = selectedOptions[group.groupKey]?.weight ?? "";
 
-        return products[0];
-      },
-      [products]
-    );
+  const matchedProduct =
+    group.products.find((p) => {
+      const variationMatch = selectedVariation ? p.Variation === selectedVariation : true;
+      const countryMatch = selectedCountry ? p.Country === selectedCountry : true;
+      const weightMatch = selectedWeight ? p.weight === selectedWeight : true;
+      return variationMatch && countryMatch && weightMatch;
+    }) ??
+    group.products[0];
 
-    const getSelectedProduct = useCallback(() => {
-      const selected = selectedOptions[groupKey] || {};
-      return getMatchingProduct(selected);
-    }, [getMatchingProduct, selectedOptions, groupKey]);
+  const product = matchedProduct;
 
-    const product = getSelectedProduct();
-    const currentQuantity = currentQuantityByProductId[product.id] ?? 0;
-    const isReordered = reorderedProductIds.includes(product.id);
+  const quantity = currentQuantityByProductId[product.id] || 0;
 
-    const variations = uniq(products.map((p) => p.Variation));
-    const origins = uniq(products.map((p) => p.Country));
-    const weights = uniq(products.map((p) => p.weight));
+  const productImages = useMemo(() => {
+    const gallery = (product.product_images ?? [])
+      .filter((img) => !!img.image_url)
+      .sort((a, b) => a.sort_order - b.sort_order);
 
-    const handleOptionChange = useCallback(
-      (type: "variation" | "countryId" | "weight", value: string) => {
-        const current = selectedOptions[groupKey] || {};
-        const nextSelection = {
-          variation: current.variation,
-          countryId: current.countryId,
-          weight: current.weight,
-          [type]: value,
-        };
+    if (gallery.length > 0) return gallery;
 
-        const matched = getMatchingProduct(nextSelection, type);
-        onOptionChange(groupKey, "variation", matched.Variation || "");
-        onOptionChange(groupKey, "countryId", matched.Country || "");
-        onOptionChange(groupKey, "weight", matched.weight || "");
-      },
-      [getMatchingProduct, onOptionChange, selectedOptions, groupKey]
-    );
-
-    const fallbackImage = `/Img/${getCategoryName(product.Category)}/${product.Product}${
-      product.Variation ? ` (${product.Variation})` : ""
-    }.png`;
-
-    const galleryImages = useMemo<GalleryImage[]>(() => {
-      const productImages = (product.product_images || [])
-        .map((img) => ({
-          image_url: img.image_url?.trim() || "",
-          public_id: img.public_id?.trim() || "",
-          is_cover: !!img.is_cover,
-          sort_order: img.sort_order ?? 0,
-        }))
-        .filter((img) => img.image_url || img.public_id)
-        .sort((a, b) => {
-          if (a.is_cover !== b.is_cover) return a.is_cover ? -1 : 1;
-          return (a.sort_order ?? 0) - (b.sort_order ?? 0);
-        });
-
-      if (productImages.length > 0) return productImages;
-
-      if (product.image_url?.trim() || product.public_id?.trim()) {
-        return [
+    return product.image_url
+      ? [
           {
-            image_url: product.image_url?.trim() || "",
-            public_id: product.public_id?.trim() || "",
-            is_cover: true,
+            id: 0,
+            product_id: product.id,
+            image_url: product.image_url,
             sort_order: 0,
+            is_cover: true,
           },
-        ];
-      }
+        ]
+      : [];
+  }, [product]);
 
-      return [
-        {
-          image_url: fallbackImage,
-          public_id: "",
-          is_cover: true,
-          sort_order: 0,
-        },
-      ];
-    }, [product.product_images, product.image_url, product.public_id, fallbackImage]);
+  const activeImage =
+    productImages[activeImageIndex]?.image_url ||
+    product.image_url ||
+    "/product-placeholder.svg";
 
-    const [selectedImage, setSelectedImage] = useState<GalleryImage | null>(null);
+  const displayName = isEnglish ? product.Product : product.Product_CH || product.Product;
+  const displayVariation = isEnglish
+    ? product.Variation
+    : product.Variation_CH || product.Variation;
+  const displayCountry = isEnglish
+    ? countryMap[product.Country]?.name || product.Country
+    : countryMap[product.Country]?.chineseName || product.Country_CH || product.Country;
 
-    useEffect(() => {
-      setSelectedImage(galleryImages[0] || null);
-    }, [galleryImages, product.id]);
+  const handleChange = (
+    type: "variation" | "countryId" | "weight",
+    value: string
+  ) => {
+    onOptionChange(group.groupKey, type, value);
+    setActiveImageIndex(0);
+  };
 
-    const mainImageSrc = selectedImage
-      ? resolveImageSrc(selectedImage.image_url, selectedImage.public_id)
-      : IMAGE_PLACEHOLDER;
+  const canOrder = isSessionValid || userRole === "admin";
 
-    return (
-      <div
-        role="article"
-        aria-label={isEnglish ? product.Product : product.Product_CH}
-        className={`relative flex flex-col overflow-hidden rounded-xl bg-white shadow-sm transition-all duration-300 hover:shadow-md ${
-          isReordered ? "animate-[pulse_1.6s_ease-in-out_3] ring-2 ring-green-400 shadow-lg" : ""
-        }`}
-      >
-        {isReordered && (
-          <div className="absolute left-2 top-2 z-10 rounded-full bg-green-500 px-2 py-1 text-xs font-semibold text-white shadow">
-            Reordered
-          </div>
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="relative aspect-square bg-gray-100">
+        <img
+          src={activeImage}
+          alt={displayName}
+          className="h-full w-full object-cover"
+        />
+
+        {userRole === "admin" && (
+          <button
+            type="button"
+            onClick={() => onOpenPhotoEditor(product)}
+            className="absolute right-2 top-2 rounded-full bg-blue-600 p-2 text-white shadow"
+            aria-label="Edit photo"
+          >
+            📷
+          </button>
         )}
+      </div>
 
-        <div className="relative bg-gray-100">
-          <div className="relative h-24 bg-gray-100 sm:h-48">
-            <ProductImage
-              key={`${product.id}-${selectedImage?.public_id || selectedImage?.image_url || "placeholder"}`}
-              src={mainImageSrc}
-              publicId=""
-              alt={isEnglish ? product.Product : product.Product_CH || product.Product}
-              className="h-full w-full object-cover"
-            />
+      {productImages.length > 1 && (
+        <div className="flex gap-2 overflow-x-auto px-3 pt-2">
+          {productImages.map((img, index) => (
+            <button
+              key={`${img.id}-${index}`}
+              type="button"
+              onClick={() => setActiveImageIndex(index)}
+              className={`h-14 w-14 shrink-0 overflow-hidden rounded border-2 ${
+                index === activeImageIndex ? "border-blue-500" : "border-gray-200"
+              }`}
+            >
+              <img
+                src={img.image_url || "/product-placeholder.svg"}
+                alt={`${displayName} ${index + 1}`}
+                className="h-full w-full object-cover"
+              />
+            </button>
+          ))}
+        </div>
+      )}
 
-            {isSessionValid && userRole === "ADMIN" && (
+      <div className="flex flex-1 flex-col p-3">
+        <h3 className="line-clamp-2 min-h-[3.5rem] text-base font-semibold leading-6 text-gray-900">
+          {displayName}
+        </h3>
+
+        <div className="mt-3">
+          <div className="text-3xl font-bold tracking-tight text-gray-900">
+            ${Number(product.price || 0).toFixed(2)}
+          </div>
+          <div className="mt-1 text-sm font-semibold text-gray-500">/{product.uom || product.UOM}</div>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          {allVariations.length > 1 && (
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+              <span className="text-[11px] uppercase tracking-wide text-gray-400 sm:min-w-[70px]">
+                {isEnglish ? "Type" : "规格"}
+              </span>
+              <select
+                className="w-full rounded-lg border border-gray-300 p-2 text-sm sm:flex-1"
+                value={selectedVariation}
+                onChange={(e) => handleChange("variation", e.target.value)}
+              >
+                {allVariations.map((variation) => {
+                  const match = group.products.find((p) => p.Variation === variation);
+                  const label = isEnglish
+                    ? variation
+                    : match?.Variation_CH || variation;
+
+                  return (
+                    <option key={variation} value={variation}>
+                      {label}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+          )}
+
+          {allCountries.length > 1 && (
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+              <span className="text-[11px] uppercase tracking-wide text-gray-400 sm:min-w-[70px]">
+                {isEnglish ? "Origin" : "产地"}
+              </span>
+              <select
+                className="w-full rounded-lg border border-gray-300 p-2 text-sm sm:flex-1"
+                value={selectedCountry}
+                onChange={(e) => handleChange("countryId", e.target.value)}
+              >
+                {allCountries.map((country) => (
+                  <option key={country} value={country}>
+                    {isEnglish
+                      ? countryMap[country]?.name || country
+                      : countryMap[country]?.chineseName || country}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {allWeights.length > 1 && (
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+              <span className="text-[11px] uppercase tracking-wide text-gray-400 sm:min-w-[70px]">
+                {isEnglish ? "Weight" : "重量"}
+              </span>
+              <select
+                className="w-full rounded-lg border border-gray-300 p-2 text-sm sm:flex-1"
+                value={selectedWeight}
+                onChange={(e) => handleChange("weight", e.target.value)}
+              >
+                {allWeights.map((weight) => (
+                  <option key={weight} value={weight}>
+                    {weight}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-4 text-sm text-gray-500">
+          {displayVariation ? <div>{displayVariation}</div> : null}
+          {displayCountry ? <div>{displayCountry}</div> : null}
+        </div>
+
+        <div className="mt-auto pt-4">
+          {!canOrder ? (
+            <button
+              type="button"
+              onClick={onOpenSignupModal}
+              disabled={isLoggingIn}
+              className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white disabled:opacity-60"
+            >
+              {isLoggingIn
+                ? isEnglish
+                  ? "Loading..."
+                  : "处理中..."
+                : isEnglish
+                ? "Sign in to order"
+                : "登录后下单"}
+            </button>
+          ) : quantity <= 0 ? (
+            <button
+              type="button"
+              onClick={() => onAddToOrder(product)}
+              className="w-full rounded-xl bg-blue-600 py-3 text-sm font-semibold text-white"
+            >
+              {isEnglish ? "Add to Cart" : "加入购物车"}
+            </button>
+          ) : (
+            <div className="flex items-center overflow-hidden rounded-xl border border-gray-300">
               <button
                 type="button"
-                className="absolute right-2 top-2 rounded-full bg-blue-500 p-2 text-white"
-                onClick={() => onOpenPhotoEditor(product)}
+                onClick={() => onUpdateQuantity(product.id, Math.max(0, quantity - 1))}
+                className="h-12 w-12 shrink-0 text-xl font-semibold text-gray-700"
               >
-                <Camera size={14} />
+                −
               </button>
-            )}
-          </div>
-
-          {galleryImages.length > 1 && (
-            <div className="flex gap-2 overflow-x-auto border-t bg-white px-2 py-2">
-              {galleryImages.slice(0, 5).map((img, index) => {
-                const thumbKey = img.public_id || img.image_url || `thumb-${index}`;
-                const thumbSelected =
-                  selectedImage?.public_id === img.public_id &&
-                  selectedImage?.image_url === img.image_url;
-
-                return (
-                  <button
-                    key={`${thumbKey}-${index}`}
-                    type="button"
-                    className={`shrink-0 overflow-hidden rounded border-2 transition ${
-                      thumbSelected ? "border-blue-500" : "border-gray-200"
-                    }`}
-                    onClick={() => setSelectedImage(img)}
-                  >
-                    <img
-                      alt={`${product.Product} ${index + 1}`}
-                      className="h-12 w-12 object-cover sm:h-14 sm:w-14"
-                      src={resolveImageSrc(img.image_url, img.public_id)}
-                      onError={(e) => {
-                        e.currentTarget.src = IMAGE_PLACEHOLDER;
-                      }}
-                    />
-                  </button>
-                );
-              })}
-
-              {galleryImages.length > 5 && (
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded border bg-gray-50 text-xs text-gray-500 sm:h-14 sm:w-14">
-                  +{galleryImages.length - 5}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-grow flex-col p-3 sm:p-4">
-          <h3 className="line-clamp-2 text-base font-bold leading-snug sm:text-lg">
-            {isEnglish ? product.Product : product.Product_CH}
-          </h3>
-          <p className="mb-3 text-xs text-gray-400">{product["Item Code"]}</p>
-
-          <div className="mb-4 space-y-3">
-            {variations.length > 1 ? (
-              <div className="flex items-center gap-2">
-                <span className="min-w-[70px] text-[11px] uppercase tracking-wide text-gray-400">
-                  {isEnglish ? "Type" : "规格"}
-                </span>
-                <select
-                  className="flex-1 rounded border p-2 text-sm"
-                  value={product.Variation || variations[0]}
-                  onChange={(e) => handleOptionChange("variation", e.target.value)}
-                >
-                  {variations.map((v) => (
-                    <option key={v} value={v}>
-                      {isEnglish ? v : products.find((p) => p.Variation === v)?.Variation_CH || v}
-                    </option>
-                  ))}
-                </select>
+              <div className="flex h-12 flex-1 items-center justify-center border-x border-gray-300 text-lg font-semibold">
+                {quantity}
               </div>
-            ) : null}
-
-            {origins.length > 1 ? (
-              <div className="flex items-center gap-2">
-                <span className="min-w-[70px] text-[11px] uppercase tracking-wide text-gray-400">
-                  {isEnglish ? "Origin" : "产地"}
-                </span>
-                <select
-                  className="flex-1 rounded border p-2 text-sm"
-                  value={product.Country || origins[0]}
-                  onChange={(e) => handleOptionChange("countryId", e.target.value)}
-                >
-                  {origins.map((o) => (
-                    <option key={o} value={o}>
-                      {isEnglish ? countryMap[o]?.name || o : countryMap[o]?.chineseName || o}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            ) : null}
-
-            {weights.length > 1 ? (
-              <div className="flex items-center gap-2">
-                <span className="min-w-[70px] text-[11px] uppercase tracking-wide text-gray-400">
-                  {isEnglish ? "Weight" : "重量"}
-                </span>
-                <select
-                  className="flex-1 rounded border p-2 text-sm"
-                  value={product.weight || weights[0]}
-                  onChange={(e) => handleOptionChange("weight", e.target.value)}
-                >
-                  {weights.map((w) => (
-                    <option key={w} value={w}>
-                      {w}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            ) : null}
-          </div>
-
-          {isSessionValid && (
-            <div className="mb-4 text-xl font-bold">
-              ${product.price.toFixed(2)}
-              <span className="text-sm text-gray-500"> /{product.UOM}</span>
-            </div>
-          )}
-
-          <div className="mt-auto border-t border-gray-100 pt-4">
-            {!isSessionValid ? (
               <button
-                disabled={isLoggingIn}
-                className="w-full text-center font-semibold text-blue-600 transition-colors hover:text-blue-800 disabled:cursor-not-allowed disabled:opacity-50"
-                onClick={onOpenSignupModal}
+                type="button"
+                onClick={() => onUpdateQuantity(product.id, quantity + 1)}
+                className="h-12 w-12 shrink-0 text-xl font-semibold text-gray-700"
               >
-                {isLoggingIn
-                  ? isEnglish
-                    ? "Logging in..."
-                    : "登录中..."
-                  : isEnglish
-                    ? "Login to see price"
-                    : "登录查看价格"}
+                +
               </button>
-            ) : (
-              <div className="flex items-center gap-2 rounded-lg px-1 py-3 sm:px-3">
-                <div className="flex items-center">
-                  <div className="flex w-fit items-stretch overflow-hidden rounded-md border bg-white">
-                    <button
-                      type="button"
-                      className="flex h-10 w-10 items-center justify-center bg-gray-100 text-base font-semibold hover:bg-gray-200"
-                      onClick={() => {
-                        if (currentQuantity > 1) onUpdateQuantity(product.id, currentQuantity - 1);
-                        else if (currentQuantity === 1) onUpdateQuantity(product.id, 0);
-                      }}
-                    >
-                      −
-                    </button>
-
-                    <input
-                      type="number"
-                      min={0}
-                      inputMode="numeric"
-                      value={currentQuantity}
-                      className="w-12 bg-white text-center text-base font-semibold outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                      onChange={(e) => {
-                        const newQuantity = parseInt(e.target.value) || 0;
-                        if (newQuantity > 0) {
-                          if (currentQuantity === 0) onAddToOrder(product);
-                          onUpdateQuantity(product.id, newQuantity);
-                        } else {
-                          onUpdateQuantity(product.id, 0);
-                        }
-                      }}
-                    />
-
-                    <button
-                      type="button"
-                      className="flex h-10 w-10 items-center justify-center bg-gray-100 text-base font-semibold hover:bg-gray-200"
-                      onClick={() => {
-                        if (currentQuantity > 0) onUpdateQuantity(product.id, currentQuantity + 1);
-                        else onAddToOrder(product);
-                      }}
-                    >
-                      +
-                    </button>
-                  </div>
-                </div>
-
-                <button
-                  type="button"
-                  title={isEnglish ? "Inquire via WhatsApp" : "通过WhatsApp询价"}
-                  className="flex h-10 w-10 items-center justify-center rounded-md bg-gray-100 text-gray-600 transition-colors hover:bg-gray-200"
-                  onClick={onCustomerService}
-                >
-                  <WhatsAppIcon className="h-4 w-4" />
-                </button>
-              </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
-    );
-  }
-);
-
-ProductCardContent.displayName = "ProductCardContent";
-
-export const ProductCard = memo<ProductCardProps>((props) => {
-  if (props.group.products.length === 0) return null;
-  return <ProductCardContent {...props} />;
-});
-
-ProductCard.displayName = "ProductCard";
+    </div>
+  );
+};


### PR DESCRIPTION
Rewrite ProductCard to a simpler functional component: remove memo wrapper and legacy helpers, replace complex matching logic with concise useMemo-based selection, and add thumbnail gallery state (activeImageIndex). Streamline props/types (use SelectedOptions and CountryMap, make reorderedProductIds required, and change onUpdateQuantity signature to (productId, qty)). Remove custom image resolver, CATEGORY_ID_NAME_MAP, ProductImage and WhatsAppIcon usage; simplify image/fallback handling and admin photo-editor button. Update ordering UX and button flows (combine session/admin ordering check, simplified add/quantity controls and signup button). Note: this contains API-breaking prop/type changes and drops several previous utilities — callers must adapt to the new prop shapes and onUpdateQuantity signature.